### PR TITLE
Accommodate planout to be able to execute sqrt and exp functions.

### DIFF
--- a/__tests__/testCoreOps.js
+++ b/__tests__/testCoreOps.js
@@ -259,6 +259,76 @@ describe ("Test core operators", function() {
     expect(x).toBe(3);
   });
 
+  it('should work with exp 1', function() {
+    var x = runConfigSingle({'op': 'exp', 'value': 1});
+    expect(x).toBe(2.718281828459045);
+  });
+
+  it('should work with exp 1 (compat)', function() {
+    var x = runConfigSingleCompat({'op': 'exp', 'value': 1});
+    expect(x).toBe(2.718281828459045);
+  });
+
+  it('should work with exp negative', function() {
+    var x = runConfigSingle({'op': 'exp', 'value': -0.5});
+    expect(x).toBe(0.6065306597126334);
+  });
+
+  it('should work with exp negative (compat)', function() {
+    var x = runConfigSingleCompat({'op': 'exp', 'value': -0.5});
+    expect(x).toBe(0.6065306597126334);
+  });
+
+  it('should work with exp non negative larger than 0 decimal', function() {
+    var x = runConfigSingle({'op': 'exp', 'value': 0.123});
+    expect(x).toBe(1.1308844209474893);
+  });
+
+  it('should work with exp non negative larger than 0 decimal (compat)', function() {
+    var x = runConfigSingleCompat({'op': 'exp', 'value': 0.123});
+    expect(x).toBe(1.1308844209474893);
+  });
+
+  it('should work with exp non negative larger than 1 decimal', function() {
+    var x = runConfigSingle({'op': 'exp', 'value': 1.88});
+    expect(x).toBe(6.553504862191148);
+  });
+
+  it('should work with exp non negative larger than 1 decimal (compat)', function() {
+    var x = runConfigSingleCompat({'op': 'exp', 'value': 1.88});
+    expect(x).toBe(6.553504862191148);
+  });
+
+  it('should work with sqrt 1', function() {
+    var x = runConfigSingle({'op': 'sqrt', 'value': 1});
+    expect(x).toBe(1);
+  });
+
+  it('should work with sqrt 1 (compat)', function() {
+    var x = runConfigSingleCompat({'op': 'sqrt', 'value': 1});
+    expect(x).toBe(1);
+  });
+
+  it('should work with sqrt non negative larger than 0', function() {
+    var x = runConfigSingle({'op': 'sqrt', 'value': 0.123});
+    expect(x).toBe(0.3507135583350036);
+  });
+
+  it('should work with sqrt non negative larger than 0 (compat)', function() {
+    var x = runConfigSingleCompat({'op': 'sqrt', 'value': 0.123});
+    expect(x).toBe(0.3507135583350036);
+  });
+
+  it('should work with sqrt non negative larger than 1', function() {
+    var x = runConfigSingle({'op': 'sqrt', 'value': 1.88});
+    expect(x).toBe(1.3711309200802089);
+  });
+
+  it('should work with sqrt non negative larger than 1 (compat)', function() {
+    var x = runConfigSingleCompat({'op': 'sqrt', 'value': 1.88});
+    expect(x).toBe(1.3711309200802089);
+  });
+
   it('should work with or', function() {
     var x = runConfigSingle({
             'op': 'or',

--- a/es6/ops/core.js
+++ b/es6/ops/core.js
@@ -196,6 +196,18 @@ class Round extends PlanOutOpUnary {
   }
 }
 
+class Exp extends PlanOutOpUnary {
+  unaryExecute(value) {
+    return Math.exp(value);
+  }
+}
+
+class Sqrt extends PlanOutOpUnary {
+  unaryExecute(value) {
+    return Math.sqrt(value);
+  }
+}
+
 class Not extends PlanOutOpUnary {
   getUnaryString() {
     return '!';
@@ -244,4 +256,4 @@ class Map extends PlanOutOpSimple {
   }
 }
 
-export { Literal, Get, Seq, Set, Arr, Map, Coalesce, Index, Cond, And, Or, Product, Sum, Equals, GreaterThan, LessThan, LessThanOrEqualTo, GreaterThanOrEqualTo, Mod, Divide, Round, Not, Negative, Min, Max, Length, Return };
+export { Literal, Get, Seq, Set, Arr, Map, Coalesce, Index, Cond, And, Or, Product, Sum, Equals, GreaterThan, LessThan, LessThanOrEqualTo, GreaterThanOrEqualTo, Mod, Divide, Round, Exp, Sqrt, Not, Negative, Min, Max, Length, Return };

--- a/es6/ops/utils.js
+++ b/es6/ops/utils.js
@@ -20,6 +20,8 @@ var initializeOperators = function(Core, Random) {
     "/": Core.Divide,
     "not": Core.Not,
     "round": Core.Round,
+    "exp": Core.Exp,
+    "sqrt": Core.Sqrt,
     "negative": Core.Negative,
     "min": Core.Min,
     "max": Core.Max,


### PR DESCRIPTION
This is related to:
1. https://github.com/facebook/planout/pull/148
2. https://github.com/facebook/planout/issues/147